### PR TITLE
markdown whitespace fix

### DIFF
--- a/src/components/poems/poem-stepper/PoemText.module.css
+++ b/src/components/poems/poem-stepper/PoemText.module.css
@@ -1,4 +1,3 @@
-/* styles.css or styles.scss */
 .customScrollbar {
   max-height: 70vh;
   min-width: 250px;
@@ -22,4 +21,8 @@
 
 .customScrollbar::-webkit-scrollbar-thumb:hover {
   background-color: rgba(0, 0, 0, 0.7);
+}
+
+.fixParagraph p {
+  margin-bottom: 1.8rem;
 }

--- a/src/components/poems/poem-stepper/PoemText.tsx
+++ b/src/components/poems/poem-stepper/PoemText.tsx
@@ -13,7 +13,7 @@ function PoemText({ poemId }: PoemProps) {
   // console.log('poemNumber', poemNumber);
 
   return (
-    <article>
+    <article className='min-w-[250px] s:min-w-xs md:min-w-[400px]'>
       <h2 className='text-4xl text-center font-tangerine mt-2 mb-4 xs:text-5xl sm:text-6xl'>
         {title}
       </h2>
@@ -21,7 +21,7 @@ function PoemText({ poemId }: PoemProps) {
         <p>{date}</p>
         <p>Poem #{poemNumber}</p>
       </div>
-      <div className={classes.customScrollbar}>
+      <div className={`${classes.customScrollbar} ${classes.fixParagraph}`}>
         <Markdown className='text-base xs:text-base sm:text-lg max-h-[70vh] overflow-y-scroll transparent-scrollbar'>
           {content}
         </Markdown>


### PR DESCRIPTION
Bug fix: the white space was being trimmed from the .md files, making all rendered poems squish into one gigantic paragraph. Added margin bottom to each markdown <p> el.