### PR TITLE
removed layout shift from month filter

### DIFF
--- a/src/components/UI/Modal/Modal.tsx
+++ b/src/components/UI/Modal/Modal.tsx
@@ -38,15 +38,6 @@ function Modal({ setYear, setMonth, setShowModal }: ModalProps) {
     }
   }, [activeYear, currentMonth, currentYear, setMonth]);
 
-  const monthsToShow = (() => {
-    if (activeYear === '2020') {
-      return allMonths.slice(7); // earliest poems are from Aug of 2020
-    } else if (activeYear === currentYear) {
-      return allMonths.slice(0, Number(currentMonth));
-    }
-    return allMonths;
-  })();
-
   const handleYearClick = (year: string) => {
     setYear(year);
     setActiveYear(year);
@@ -62,10 +53,23 @@ function Modal({ setYear, setMonth, setShowModal }: ModalProps) {
     setActiveMonth(month);
   };
 
+  const isMonthInactive = (month: string) => {
+    if (activeYear === '2020' && Number(month) <= 7) {
+      return true;
+    } else if (
+      activeYear === currentYear &&
+      Number(month) > Number(currentMonth)
+    ) {
+      return true;
+    }
+    return false;
+  };
+
   return (
     <div className='fixed inset-0 bg-gray-9 bg-opacity-90 overflow-y-auto h-full w-full flex items-center justify-center'>
       <div className='w-60 bg-gray-0 shadow-lg rounded-md px-4 py-6 xs:w-72 xs:p-8 sm:w-96'>
         <div className='text-center'>
+          {/* YEAR SECTION */}
           <div>
             <h3 className='text-5xl font-tangerine font-bold text-gray-9 mb-4'>
               Year
@@ -86,22 +90,28 @@ function Modal({ setYear, setMonth, setShowModal }: ModalProps) {
               ))}
             </div>
           </div>
+
+          {/* MONTH SECTION */}
           <div>
             <h3 className='text-5xl font-tangerine font-bold text-gray-9 mb-4'>
               Month
             </h3>
             <div className='grid grid-cols-3 gap-4 mb-8'>
-              {monthsToShow.map((month) => {
+              {allMonths.map((month) => {
                 const shortMonthName = monthNumberToShortMonthName(month);
+                const isInactive = isMonthInactive(month);
 
                 return (
                   <button
                     key={month}
-                    onClick={() => handleMonthClick(month)}
-                    className={`px-2 py-1 font-bold rounded-md shadow-sm focus:outline-none focus:ring-4 hover:ring-4 ${
-                      activeMonth === month
+                    onClick={() => !isInactive && handleMonthClick(month)}
+                    disabled={isInactive}
+                    className={`px-2 py-1 font-bold rounded-md shadow-sm focus:outline-none ${
+                      isInactive
+                        ? 'bg-gray-2 text-gray-6 cursor-not-allowed'
+                        : activeMonth === month
                         ? 'border-2 border-gray-8 ring-4 ring-gray-8'
-                        : 'bg-gray-0 text-gray-8 border-2 border-gray-8'
+                        : 'bg-gray-0 text-gray-8 border-2 border-gray-8 hover:ring-4'
                     }`}
                   >
                     {shortMonthName}
@@ -110,6 +120,8 @@ function Modal({ setYear, setMonth, setShowModal }: ModalProps) {
               })}
             </div>
           </div>
+
+          {/* SEARCH BUTTON */}
           <div className='flex justify-center mt-4 gap-6'>
             <button
               onClick={() => setShowModal(false)}

--- a/src/components/poems/AllPoems.tsx
+++ b/src/components/poems/AllPoems.tsx
@@ -20,22 +20,6 @@ export interface AllPoemsProps {
   poems: Poem[];
 }
 
-function filterPoemsByYearAndMonth(
-  poems: Poem[],
-  year: string,
-  month: string
-): Poem[] {
-  return poems
-    .filter((poem) => {
-      const poemDate = new Date(poem.date);
-      const poemYear = poemDate.getFullYear().toString();
-      const poemMonth = (poemDate.getMonth() + 1).toString().padStart(2, '0');
-
-      return poemYear === year && poemMonth === month;
-    })
-    .sort((poemA, poemB) => poemA.date.localeCompare(poemB.date));
-}
-
 function AllPoems({ poems }: AllPoemsProps) {
   const [year, setYear] = useState<string>('2020');
   const [month, setMonth] = useState<string>('08');


### PR DESCRIPTION
# [eliminate layout shifts in date filter](https://trello.com/c/9w90POGm)

## **Changes** // reasons why

- changed UI on filter modal to always show 12 months // eliminates shift
- added inactive styling for 1st 7 months of 2020 // no poems from that date range

## **Additional Notes**

- removed filterPoemsByYearAndMonth function from AllPoems.tsx // it was not being used
