### PR TITLE
poem date bugs

### DIFF
--- a/poems/poem-0080.md
+++ b/poems/poem-0080.md
@@ -1,6 +1,6 @@
 ---
 title: "All The Tea In China"
-date: "2020-11-04  "
+date: "2020-11-04"
 excerpt: "How did they keep them fresh"
 isFeatured: "false"
 poemNumber: "80"

--- a/poems/poem-0094b.md
+++ b/poems/poem-0094b.md
@@ -1,6 +1,6 @@
 ---
 title: "The Big Thaw"
-date: "2020-11-11  "
+date: "2020-11-11"
 excerpt: "As goes the ice"
 isFeatured: "false"
 poemNumber: "94b"


### PR DESCRIPTION
# [Poems 80 & 94 B not showing a date](https://trello.com/c/fHM3x601)

## **Changes** // reasons why

- removed extra whitespace from end of .md file metadata date string // was causing date to not appear in UI of the filtered poems list
